### PR TITLE
Normalize result path for each document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/fileextension/out/
 test/fileextension/node_modules/
 node_modules/
 out/
+.idea

--- a/src/dateurls.plugin.coffee
+++ b/src/dateurls.plugin.coffee
@@ -1,5 +1,6 @@
 post_date_regex = new RegExp("([0-9]+-)*")
 moment = require('moment')
+pathUtil = require('path')
 
 # Export Plugin 
 module.exports = (BasePlugin) ->
@@ -46,7 +47,7 @@ module.exports = (BasePlugin) ->
           getFilename = 'outFilename'
         documents = @docpad.getCollection(config.collectionName)
         documents.forEach (document) ->
-          dateUrl = moment.utc(document.getMeta('date')).format(config.dateFormat)+"/"+document.get(getFilename).replace(post_date_regex,'')
+          dateUrl = pathUtil.normalize(moment.utc(document.getMeta('date')).format(config.dateFormat)+"/"+document.get(getFilename).replace(post_date_regex,''))
           if config.cleanurl
               document.setUrl(dateUrl + if trailingSlashes then '/' else '')
               document.addUrl(dateUrl + if trailingSlashes then '' else '/')

--- a/test/cleanurls/out-expected/posts/2013-03-01-file-without-date-property.html
+++ b/test/cleanurls/out-expected/posts/2013-03-01-file-without-date-property.html
@@ -1,1 +1,1 @@
-/2014/06/23/file-without-date-property
+/2014/06/24/file-without-date-property

--- a/test/fileextension/out-expected/posts/2013-03-01-file-without-date-property.html
+++ b/test/fileextension/out-expected/posts/2013-03-01-file-without-date-property.html
@@ -1,1 +1,1 @@
-/2014/06/23/file-without-date-property.html
+/2014/06/24/file-without-date-property.html

--- a/test/trailingslash/out-expected/posts/2013-03-01-file-without-date-property.html
+++ b/test/trailingslash/out-expected/posts/2013-03-01-file-without-date-property.html
@@ -1,1 +1,1 @@
-/2014/06/23/file-without-date-property/
+/2014/06/24/file-without-date-property/


### PR DESCRIPTION
Hi!
I have a task to compile all posts to root folder. (I think many people stuck with that problem)
```
/src/posts/hello-world.html.md -> out/hello-world/index.html
```
Also I like to number my posts in source dir
```
/src/posts/001-hello-world.html.md -> out/hello-world/index.html
```
I started to write my own plugin, but then realize, that dateurls can solve all my requires (with cleanurls, of course).
All I need is to write in your new option
```
dateFormat: '/'
```
And just normalize path to avoid '//' in very start - this is what have I done in my fork.
I know it's some kind of unusual but witty way of using dateurls.